### PR TITLE
Call designated initializer of superclass

### DIFF
--- a/STableViewController/STableViewController.m
+++ b/STableViewController/STableViewController.m
@@ -38,9 +38,9 @@
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-- (id) init
+- (id) initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-  if ((self = [super init]))
+  if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]))
     [self initialize];  
   return self;
 }


### PR DESCRIPTION
We should call designated initializer of superclass while initialization, otherwise, it will cause problem when subclassing STableViewController.
